### PR TITLE
Fix "Hello World" query (replace url field)

### DIFF
--- a/src/Queries/index.js
+++ b/src/Queries/index.js
@@ -349,7 +349,7 @@ const HELLO_WORLD = `
 {
   generalSettings{
     title
-    url
+    description
 		language
   }
 }


### PR DESCRIPTION
Replace the invalid `url` field with `description` (a valid field) on
generalSettings in the "Hello World" query.

See #4